### PR TITLE
Add rudimentary support for parsing file descriptors.

### DIFF
--- a/include/arpc++/arpc++.h
+++ b/include/arpc++/arpc++.h
@@ -10,12 +10,27 @@
 
 namespace arpc {
 
+class FileDescriptor {
+ private:
+  FileDescriptor(FileDescriptor const&) = delete;
+  void operator=(FileDescriptor const& x) = delete;
+};
+
+class FileDescriptorParser {
+ public:
+  virtual ~FileDescriptorParser() {
+  }
+
+  virtual std::shared_ptr<FileDescriptor> Get(const argdata_t& ad) = 0;
+};
+
 class Message {
  public:
   virtual ~Message() {
   }
 
-  virtual void Parse(const argdata_t& ad) = 0;
+  virtual void Parse(const argdata_t& ad,
+                     FileDescriptorParser* file_descriptor_parser) = 0;
 };
 
 class Service {


### PR DESCRIPTION
Let Parse() take an additional pointer to a FileDescriptorParser that
can be used to convert argdata_t's representing file descriptors to
std::shared_ptr<FileDescriptor> objects.

When processing actual incoming RPCs, this class can extract file
descriptors using argdata_reader_release_fd(). When dealing with fictive
requests, e.g. by piggy-backing a client and a server within the same
process, this can duplicate the shared_ptr that was used on the client
side.